### PR TITLE
chore: exports types

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ import {
   PluginConfig,
   GenerateURL,
   GenerateLabel,
-} from "@payloadcms/plugin-nested-docs/dist/types";
+} from "@payloadcms/plugin-nested-docs/types";
 ```
 
 ## Development
@@ -242,5 +242,3 @@ To actively develop or debug this plugin you can either work directly within the
    ```
 
 ## Screenshots
-
-<!-- ![screenshot 1](https://github.com/@payloadcms/plugin-nested-docs/blob/main/images/screenshot-1.jpg?raw=true) -->

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "typescript": "^4.5.5"
   },
   "files": [
-    "dist"
+    "dist",
+    "types.js",
+    "types.d.ts"
   ]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/types';

--- a/types.js
+++ b/types.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/types');


### PR DESCRIPTION
Exports types top-level so they can be imported like this: `"@payloadcms/plugin-nested-docs/types"` instead of this: `"@payloadcms/plugin-nested-docs/dist/types"`