### PR TITLE
chore: exports fields top-level

### DIFF
--- a/fields.d.ts
+++ b/fields.d.ts
@@ -1,0 +1,2 @@
+export * from './dist/fields/breadcrumbs';
+export * from './dist/fields/parent';

--- a/fields.js
+++ b/fields.js
@@ -1,0 +1,7 @@
+const breadcrumbs = require('./dist/fields/breadcrumbs');
+const parent = require('./dist/fields/parent');
+
+module.exports = {
+  breadcrumbs,
+  parent
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "files": [
     "dist",
+    "fields.js",
+    "fields.d.ts",
     "types.js",
     "types.d.ts"
   ]


### PR DESCRIPTION
Exports fields top-level as the README.md describes:

```ts
import createParentField from "@payloadcms/plugin-nested-docs/fields/parent";
import createBreadcrumbsField from "@payloadcms/plugin-nested-docs/fields/breadcrumbs";
```

Originally identified in Discord here: https://discord.com/channels/967097582721572934/967097582721572937/1069934325707051089