### PR TITLE
fix: threads locale through resaveChildren

### DIFF
--- a/demo/src/collections/Pages.ts
+++ b/demo/src/collections/Pages.ts
@@ -1,6 +1,8 @@
 // const payload = require('payload');
 import type { CollectionConfig } from 'payload/types'
 
+import populateFullTitle from './populateFullTitle'
+
 export const Pages: CollectionConfig = {
   slug: 'pages',
   labels: {
@@ -8,7 +10,7 @@ export const Pages: CollectionConfig = {
     plural: 'Pages',
   },
   admin: {
-    useAsTitle: 'title',
+    useAsTitle: 'fullTitle',
   },
   access: {
     read: () => true,
@@ -25,6 +27,19 @@ export const Pages: CollectionConfig = {
       label: 'Slug',
       type: 'text',
       required: true,
+    },
+    {
+      name: 'fullTitle',
+      type: 'text',
+      localized: true,
+      hooks: {
+        beforeChange: [populateFullTitle],
+      },
+      admin: {
+        components: {
+          Field: () => null,
+        },
+      },
     },
   ],
 }

--- a/demo/src/collections/populateFullTitle.ts
+++ b/demo/src/collections/populateFullTitle.ts
@@ -1,0 +1,17 @@
+import type { FieldHook } from 'payload/types'
+
+export const generateFullTitle = (breadcrumbs: Array<{ label: string }>): string | undefined => {
+  if (Array.isArray(breadcrumbs)) {
+    return breadcrumbs.reduce((title, breadcrumb, i) => {
+      if (i === 0) return `${breadcrumb.label}`
+      return `${title} > ${breadcrumb.label}`
+    }, '')
+  }
+
+  return undefined
+}
+
+const populateFullTitle: FieldHook = async ({ data, originalDoc }) =>
+  generateFullTitle(data?.breadcrumbs || originalDoc?.breadcrumbs)
+
+export default populateFullTitle

--- a/demo/src/payload.config.ts
+++ b/demo/src/payload.config.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { buildConfig } from 'payload/config'
 
 // import nestedPages from '../../dist';
-import nestedPages from '../../src'
+import nestedPages from '../../src' // eslint-disable-line import/no-relative-packages
 import { Pages } from './collections/Pages'
 import { Users } from './collections/Users'
 
@@ -28,15 +28,11 @@ export default buildConfig({
     },
   },
   collections: [Users, Pages],
-  //  localization: {
-  //   locales: [
-  //     'en',
-  //     'es',
-  //     'de',
-  //   ],
-  //   defaultLocale: 'en',
-  //   fallback: true,
-  // },
+  localization: {
+    locales: ['en', 'es', 'de'],
+    defaultLocale: 'en',
+    fallback: true,
+  },
   plugins: [
     nestedPages({
       collections: ['pages'],

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -14,6 +14,7 @@
     "jsx": "react",
   },
   "ts-node": {
-    "transpileOnly": true
+    "transpileOnly": true,
+    "swc": true
   }
 }

--- a/src/fields/breadcrumbs.ts
+++ b/src/fields/breadcrumbs.ts
@@ -7,6 +7,7 @@ const createBreadcrumbsField = (
 ): Field => ({
   name: 'breadcrumbs',
   type: 'array',
+  localized: true,
   fields: [
     {
       name: 'doc',

--- a/src/hooks/resaveChildren.ts
+++ b/src/hooks/resaveChildren.ts
@@ -5,7 +5,7 @@ import populateBreadcrumbs from '../utilities/populateBreadcrumbs'
 
 const resaveChildren =
   (pluginConfig: PluginConfig, collection: CollectionConfig): CollectionAfterChangeHook =>
-  ({ req: { payload }, req, doc }) => {
+  ({ req: { payload, locale }, req, doc }) => {
     const resaveChildrenAsync = async (): Promise<void> => {
       const children = await payload.find({
         collection: collection.slug,
@@ -15,6 +15,7 @@ const resaveChildren =
           },
         },
         depth: 0,
+        locale,
       })
 
       try {
@@ -33,6 +34,7 @@ const resaveChildren =
               breadcrumbs: populateBreadcrumbs(req, pluginConfig, collection, child),
             },
             depth: 0,
+            locale,
           })
         })
       } catch (err: unknown) {

--- a/src/hooks/resaveSelfAfterCreate.ts
+++ b/src/hooks/resaveSelfAfterCreate.ts
@@ -11,7 +11,7 @@ interface DocWithBreadcrumbs {
 
 const resaveSelfAfterCreate =
   (collection: CollectionConfig): CollectionAfterChangeHook =>
-  async ({ req: { payload }, doc, operation }) => {
+  async ({ req: { payload, locale }, doc, operation }) => {
     const { breadcrumbs = [] } = doc as DocWithBreadcrumbs
 
     if (operation === 'create') {
@@ -30,6 +30,7 @@ const resaveSelfAfterCreate =
         await payload.update({
           collection: collection.slug,
           id: doc.id,
+          locale,
           depth: 0,
           draft: updateAsDraft,
           data: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,11 +20,7 @@ const nestedDocs =
         }
 
         if (!pluginConfig.breadcrumbsFieldSlug) {
-          fields.push(
-            createBreadcrumbsField(collection.slug, {
-              localized: Boolean(config.localization),
-            }),
-          )
+          fields.push(createBreadcrumbsField(collection.slug))
         }
 
         return {


### PR DESCRIPTION
Closes https://github.com/payloadcms/plugin-nested-docs/issues/23 by threading `locale` through `resaveChildren`. Previously, we were only updating the default locale in our recursive function. Now, we pass the user's current locale via `req.locale`.