### PR TITLE
Add feature: breadcrumbs across multiple collections

### DIFF
--- a/src/fields/parent.ts
+++ b/src/fields/parent.ts
@@ -1,7 +1,9 @@
 import type { RelationshipField } from 'payload/dist/fields/config/types'
 
 const createParentField = (
-  relationTo: string,
+  // Pass a single collection or an array of collections
+  // If no createParentField found in collectionConfig, the default collection is used
+  relationTo: string | string[],
   overrides?: Partial<
     RelationshipField & {
       hasMany: false

--- a/src/hooks/resaveChildren.ts
+++ b/src/hooks/resaveChildren.ts
@@ -1,25 +1,47 @@
+import type { Config } from 'payload/config'
 import type { CollectionAfterChangeHook, CollectionConfig } from 'payload/types'
 
 import type { PluginConfig } from '../types'
 import populateBreadcrumbs from '../utilities/populateBreadcrumbs'
 
 const resaveChildren =
-  (pluginConfig: PluginConfig, collection: CollectionConfig): CollectionAfterChangeHook =>
+  (
+    config: Config,
+    pluginConfig: PluginConfig,
+    collection: CollectionConfig,
+  ): CollectionAfterChangeHook =>
   ({ req: { payload, locale }, req, doc }) => {
     const resaveChildrenAsync = async (): Promise<void> => {
-      const children = await payload.find({
-        collection: collection.slug,
-        where: {
-          parent: {
-            equals: doc.id,
+      // Fetch within all collections present in pluginConfig.collections
+      // to find all documents with the current doc as parent
+      const promises = pluginConfig.collections?.map(collectionItem => {
+        const collectionConfig = config?.collections?.find(item => item.slug === collectionItem)
+        const collectionParentField = collectionConfig?.fields?.find(
+          field => field.type === 'relationship' && field.name === 'parent',
+        )
+        // Retrieve collection parent field type
+        const parentFilter =
+          collectionParentField?.type === 'relationship' &&
+          typeof collectionParentField?.relationTo === 'string'
+            ? 'parent'
+            : 'parent.value'
+
+        return payload.find({
+          collection: collectionItem,
+          where: {
+            [parentFilter]: {
+              equals: doc.id,
+            },
           },
-        },
-        depth: 0,
-        locale,
+          depth: 0,
+          locale,
+        })
       })
 
+      const children = await (await Promise.all(promises)).map(results => results.docs).flat()
+
       try {
-        children.docs.forEach((child: any) => {
+        children.forEach((child: any) => {
           const updateAsDraft =
             typeof collection.versions === 'object' &&
             collection.versions.drafts &&
@@ -31,7 +53,7 @@ const resaveChildren =
             draft: updateAsDraft,
             data: {
               ...child,
-              breadcrumbs: populateBreadcrumbs(req, pluginConfig, collection, child),
+              breadcrumbs: populateBreadcrumbs(req, config, pluginConfig, collection, child),
             },
             depth: 0,
             locale,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,11 +29,11 @@ const nestedDocs =
             ...(collection.hooks || {}),
             beforeChange: [
               async ({ req, data, originalDoc }) =>
-                populateBreadcrumbs(req, pluginConfig, collection, data, originalDoc),
+                populateBreadcrumbs(req, config, pluginConfig, collection, data, originalDoc),
               ...(collection?.hooks?.beforeChange || []),
             ],
             afterChange: [
-              resaveChildren(pluginConfig, collection),
+              resaveChildren(config, pluginConfig, collection),
               resaveSelfAfterCreate(collection),
               ...(collection?.hooks?.afterChange || []),
             ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface Breadcrumb {
   url?: string
   label: string
   doc: string
+  collection: string
 }
 
 export type GenerateURL = (

--- a/src/utilities/formatBreadcrumb.ts
+++ b/src/utilities/formatBreadcrumb.ts
@@ -27,6 +27,9 @@ const formatBreadcrumb = (
     label,
     url,
     doc: lastDoc.id as string,
+    // Add collection field into breadcrumbs
+    // Useful to retrieve each document data later in front-end if more info needed
+    collection: (lastDoc.collection as string) || collection.slug,
   }
 }
 

--- a/src/utilities/getParents.ts
+++ b/src/utilities/getParents.ts
@@ -1,37 +1,58 @@
+import type { Config } from 'payload/config'
+import type { ValueWithRelation } from 'payload/dist/fields/config/types'
 import type { CollectionConfig } from 'payload/types'
 
 import type { PluginConfig } from '../types'
+import isValueWithRelation from './isValueWithRelation'
+import retrieveParentCollection from './retrieveParentCollection'
 
 const getParents = async (
   req: any,
+  config: Config,
   pluginConfig: PluginConfig,
   collection: CollectionConfig,
   doc: Record<string, unknown>,
   docs: Array<Record<string, unknown>> = [],
 ): Promise<Array<Record<string, unknown>>> => {
-  const parent = doc[pluginConfig?.parentFieldSlug || 'parent']
   let retrievedParent
+  const parent = doc[pluginConfig?.parentFieldSlug || 'parent'] as string | ValueWithRelation | null
+  const retrievedParentCollection =
+    retrieveParentCollection(config, pluginConfig, collection, parent) || collection
 
   if (parent) {
+    // If parent target an array of collections, receive parent = {value: id, relationTo: collection}
+    if (typeof parent === 'object' && isValueWithRelation(parent)) {
+      retrievedParent = await req.payload.findByID({
+        req,
+        id: parent.value,
+        collection: retrievedParentCollection.slug,
+        depth: 0,
+        disableErrors: true,
+      })
+    }
+
     // If not auto-populated, and we have an ID
     if (typeof parent === 'string') {
       retrievedParent = await req.payload.findByID({
         req,
         id: parent,
-        collection: collection.slug,
+        collection: retrievedParentCollection.slug,
         depth: 0,
         disableErrors: true,
       })
     }
 
     // If auto-populated
-    if (typeof parent === 'object') {
+    if (typeof parent === 'object' && !isValueWithRelation(parent)) {
       retrievedParent = parent
     }
 
+    // Insert collection slug into doc (needed during formatBreadcrumb)
+    retrievedParent.collection = retrievedParentCollection.slug
+
     if (retrievedParent) {
       if (retrievedParent.parent) {
-        return getParents(req, pluginConfig, collection, retrievedParent, [
+        return getParents(req, config, pluginConfig, retrievedParentCollection, retrievedParent, [
           retrievedParent,
           ...docs,
         ])

--- a/src/utilities/isValueWithRelation.ts
+++ b/src/utilities/isValueWithRelation.ts
@@ -1,0 +1,9 @@
+import type { ValueWithRelation } from 'payload/dist/fields/config/types'
+
+const isValueWithRelation = (
+  parentField: string | ValueWithRelation | null,
+): parentField is ValueWithRelation => {
+  return typeof parentField === 'object' && typeof parentField?.relationTo === 'string'
+}
+
+export default isValueWithRelation

--- a/src/utilities/populateBreadcrumbs.ts
+++ b/src/utilities/populateBreadcrumbs.ts
@@ -1,3 +1,4 @@
+import type { Config } from 'payload/config'
 import type { CollectionConfig } from 'payload/types'
 
 import type { PluginConfig } from '../types'
@@ -6,6 +7,7 @@ import getParents from './getParents'
 
 const populateBreadcrumbs = async (
   req: any,
+  config: Config,
   pluginConfig: PluginConfig,
   collection: CollectionConfig,
   data: any,
@@ -13,7 +15,7 @@ const populateBreadcrumbs = async (
 ): Promise<any> => {
   const newData = data
   const breadcrumbDocs = [
-    ...(await getParents(req, pluginConfig, collection, {
+    ...(await getParents(req, config, pluginConfig, collection, {
       ...originalDoc,
       ...data,
     })),

--- a/src/utilities/retrieveParentCollection.ts
+++ b/src/utilities/retrieveParentCollection.ts
@@ -1,0 +1,41 @@
+import type { Config } from 'payload/config'
+import type { ValueWithRelation } from 'payload/dist/fields/config/types'
+import type { CollectionConfig } from 'payload/types'
+
+import type { PluginConfig } from '../types'
+import isValueWithRelation from './isValueWithRelation'
+
+// Return the collection config of selected parent instead of default collection (previous behavior)
+const retrieveParentCollection = (
+  config: Config,
+  pluginConfig: PluginConfig,
+  collection: CollectionConfig,
+  parent: string | ValueWithRelation | null,
+): CollectionConfig | undefined => {
+  let parentCollection
+
+  // Parent target an array of collections
+  if (typeof parent === 'object' && isValueWithRelation(parent)) {
+    parentCollection =
+      config.collections?.find(item => item.slug === parent.relationTo) || collection
+  }
+
+  // Parent target a single collection
+  if (typeof parent === 'string') {
+    // retrieve parent field in collection config
+    const parentField = collection.fields.find(
+      field =>
+        field?.type === 'relationship' &&
+        field?.name === (pluginConfig.parentFieldSlug || 'parent'),
+    )
+
+    // use collection related within createParentField
+    if (parentField?.type === 'relationship' && typeof parentField?.relationTo === 'string') {
+      parentCollection = config.collections?.find(item => item.slug === parentField?.relationTo)
+    }
+  }
+
+  return parentCollection
+}
+
+export default retrieveParentCollection


### PR DESCRIPTION
        - createParentField accept single collection (current collection or another one)
        - createParentField accept collections array
        - add "collection" field to breadcrumb type
        - breadcrumbs accept any kind of depth / collection / complexity